### PR TITLE
chore (ci): add markdown linter and link check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,27 @@
+name: Markdown Linter
+# Lint runs the markdown linter over all markdown files in the docs repository.
+# This workflow is run on every pull request and push to main.
+# The linter will pass without running if no *.md files have been changed.
+on: 
+  pull_request:
+    paths:
+      - '**.md'
+  push:
+    branches:
+      - main
+    paths:
+      - '**.md'
+
+jobs:
+  markdown-lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v3
+      - uses: nosborn/github-action-markdown-cli@v3.2.0
+        with:
+          files: .
+          config_file: .markdownlint.yml
+          # ignore_path: .markdownlintignore
+        # Check only if there are differences in the source code
+        if: env.GIT_DIFF

--- a/.github/workflows/markdown-links.yml
+++ b/.github/workflows/markdown-links.yml
@@ -1,0 +1,23 @@
+name: Check Markdown links
+on: 
+  pull_request:
+    paths:
+      - '**.md'
+  push:
+    branches:
+      - main
+    paths:
+      - '**.md'
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: gaurav-nelson/github-action-markdown-link-check@master
+        with:
+          folder-path: "docs"
+          check-modified-files-only: "yes"
+          use-quiet-mode: "yes"
+          base-branch: "main"
+          config-file: "mlc_config.json"

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,24 @@
+"default": true
+"MD001": false
+"MD004": false
+"MD007":
+  "indent": 4
+"MD024":
+  "siblings_only": true
+"MD025": false
+"MD026":
+  "punctuation": ".;:"
+"MD029": false
+"MD033": false
+"MD034": false
+"MD036": false
+"MD040": false
+"MD041": false
+"MD051": false
+"MD049":
+  "style": "asterisk"
+"MD013":
+  "line_length": 120
+  "code_blocks": false
+  "tables": false
+"no-hard-tabs": false

--- a/mlc_config.json
+++ b/mlc_config.json
@@ -1,0 +1,5 @@
+{
+    "retryOn429": true,
+    "retryCount": 3,
+    "fallbackRetryDelay": "20s"
+}


### PR DESCRIPTION
I noticed we didn't include any linters in the repo yet. This PR adds the markdown linter and the link checker from the Evmos repo.