### PR TITLE
docs(use): add transfer tokens content and move details about tokens to concepts

### DIFF
--- a/docs/protocol/concepts/tokens.md
+++ b/docs/protocol/concepts/tokens.md
@@ -4,4 +4,22 @@ sidebar_position: 5
 
 # Tokens
 
-MOVED THIS TO THE INTRO OF EVMOS IN USE. Can delete or fill if that is not correct
+Evmos uses [Atto](https://en.wikipedia.org/wiki/Atto-) EVMOS as the base denomination to maintain parity with Ethereum.
+
+1 evmos = 10<sup>18</sup> aevmos
+
+This matches Ethereum denomination of:
+
+1 ETH = 10<sup>18</sup> wei
+
+
+### Cosmos Coins
+
+Accounts can own Cosmos coins in their balance, which are used for operations with other Cosmos and transactions. Examples of these are using the coins for staking, IBC transfers, governance deposits and EVM.
+
+### EVM Tokens
+
+Evmos is compatible with ERC20 tokens and other non-fungible token standards (EIP721, EIP1155)
+that are natively supported by the EVM.
+
+

--- a/docs/use/get-started/index.mdx
+++ b/docs/use/get-started/index.mdx
@@ -44,29 +44,9 @@ import ProjectValue from '@site/src/components/ProjectValue.js';
 | Evmos Testnet          | <ProjectValue keyword="testnet_chain_id" />                |
 | Evmos Mainnet          | <ProjectValue keyword="chain_id" />                        |
 | Blockchain Explorer(s) | [List of Block Explorers](/develop/build-a-dApp/tools/block-explorers) |
-| Block Time             | `~2s`                                                      | 
+| Block Time             | `~2s`                                                      |
 
 ## Introduction
 
 Evmos is a Cosmos-based chain with full Ethereum Virtual Machine (EVM) support. Because of this [architecture](./../protocol), tokens and assets in the network may come from different independent sources.
 
-## The EVMOS Token
-
-The denomination used for staking, governance and gas consumption on the EVM is the EVMOS. The EVMOS provides the utility of: securing the Proof-of-Stake chain, token used for governance proposals, distribution of fees to validator and users, and as a mean of gas for running smart contracts on the EVM.
-
-Evmos uses [Atto](https://en.wikipedia.org/wiki/Atto-) EVMOS as the base denomination to maintain parity with Ethereum.
-
-1 evmos = 10<sup>18</sup> aevmos
-
-This matches Ethereum denomination of:
-
-1 ETH = 10<sup>18</sup> wei
-
-## Cosmos Coins
-
-Accounts can own Cosmos coins in their balance, which are used for operations with other Cosmos and transactions. Examples of these are using the coins for staking, IBC transfers, governance deposits and EVM.
-
-## EVM Tokens
-
-Evmos is compatible with ERC20 tokens and other non-fungible token standards (EIP721, EIP1155)
-that are natively supported by the EVM.

--- a/docs/use/transfer-tokens/index.md
+++ b/docs/use/transfer-tokens/index.md
@@ -5,14 +5,35 @@ slug: '/transfer'
 
 # Transfer Tokens
 
-Fill in more content here.
+Once connected to the Evmos network, you can use your wallet to transfer tokens peer-to-peer without the need for a bank or an intermediary payment service. This gives you full ownership of your assets but also full responsibility for safekeeping your passwords.
+
+Using either your wallet directly or connecting it to a dApp like the [Evmos Assets page](https://app.evmos.org/assets), gives you access to view your token balances, transfer tokens on the Evmos network, or deposit & withdraw tokens from & to other blockchain networks.
 
 ## View Balances
 
-## Onramp Evmos
+You can view the balances of all your crypto assets on Evmos, both the native $EVMOS token and assets that have been created on or sent to the Evmos network from other blockchains. The balance of an asset is described by the number of tokens and the equivalent value in $USD.
 
-## Sending Evmos
+Like any other currency, crypto assets can be used as a storage of value or a medium of exchange. Only if an asset is traded on an exchange, its price can be determined by demand and supply against other assets. The native $EVMOS token provides additional utility on Evmos as it is used to secure the network through staking, vote governance proposals, and pay for gas.
 
-## Receiving Evmos
+On Evmos, assets can be represented as different types of tokens (e.g. Cosmos IBC Coins or EVM ERC20 tokens). We believe, however, that unless you are a developer, you don't need to be concerned with the underlying representation of a token. You just use the asset name and the Evmos network performs conversions between representations automatically.
 
-## IBC Transfer To Another Network
+<!-- TODO add assets page -->
+<!-- ![Evmos Assets page](img/evmos_dapps_assets.png) -->
+
+## Onramp to Evmos
+
+Onramping to Evmos (obtaining $EVMOS tokens) is required to start using Evmos as you need a small amount of "gas" to transfer assets or interact with dApps. This prevents users from spamming the network for free and paid gas is used to reward developers.
+
+Here are some examples of how to onramp to Evmos:
+
+* Use an exchange (e.g. Osmosis) to another asset for $EVMOS
+* Ask a friend to transfer you $EVMOS
+* Use services that allow you to exchange fiat currencies (e.g. $USD) for cryptocurrencies, (e.g. [C14](https://www.c14.money/buy))
+
+## Send Assets on the same Chain
+
+Sending and receiving Assets from one account on Evmos to another account on Evmos can be done directly through your wallet (e.g. Keplr/Metamask). To `send` assets you will have to provide the address of the receiving account, either in its Ethereum (e.g. `0x47EeB2eac350E1923b8CBDfA4396A077b36E62a0`) or Cosmos format (e.g. `evmos1glht96kr2rseywuvhhay894qw7ekuc4qg9z5nw`).
+
+## Deposit and Withdraw Assets across Chains
+
+Depositing assets from another blockchain to Evmos or withdrawing assets from Evmos to another blockchain is possible using the Evmos [Evmos Assets page](https://app.evmos.org/assets). This is useful, for example to onramp to Evmos or offramp Evmos into fiat currency.

--- a/docs/use/transfer-tokens/index.md
+++ b/docs/use/transfer-tokens/index.md
@@ -13,7 +13,7 @@ Using either your wallet directly or connecting it to a dApp like the [Evmos Ass
 
 You can view the balances of all your crypto assets on Evmos, both the native $EVMOS token and assets that have been created on or sent to the Evmos network from other blockchains. The balance of an asset is described by the number of tokens and the equivalent value in $USD.
 
-Like any other currency, crypto assets can be used as a storage of value or a medium of exchange. Only if an asset is traded on an exchange, its price can be determined by demand and supply against other assets. The native $EVMOS token provides additional utility on Evmos as it is used to secure the network through staking, vote governance proposals, and pay for gas.
+Like any other currency, crypto assets can be used as a storage of value or a medium of exchange. Only if an asset is traded on an exchange, its price can be determined by demand and supply against other assets. The native $EVMOS token provides additional utility on Evmos as it is used to secure the network through [staking](https://app.evmos.org/staking), vote on [governance](https://app.evmos.org/governance) proposals, and pay for gas.
 
 On Evmos, assets can be represented as different types of tokens (e.g. Cosmos IBC Coins or EVM ERC20 tokens). We believe, however, that unless you are a developer, you don't need to be concerned with the underlying representation of a token. You just use the asset name and the Evmos network performs conversions between representations automatically.
 


### PR DESCRIPTION
## Description

Adds content for the `use/transfer` page. Note that I moved some content to the protocol section so that it will be worked on once we get to that section.

I also discovered that it would be nice for users to send tokens to other accounts on Evmos using the assets page. Right now, users have to use wallets and understand technical terms like (IBC, ERC20 etc.)