### PR TITLE
Update snapshots-archives.mdx

### DIFF
--- a/docs/develop/api/snapshots-archives.mdx
+++ b/docs/develop/api/snapshots-archives.mdx
@@ -14,6 +14,7 @@ archived [9001-1 mainnet](https://github.com/evmos/mainnet/tree/main/evmos_9001-
 | `Staketab`   | [github.com/staketab/nginx-cosmos-snap](https://github.com/staketab/nginx-cosmos-snap/blob/main/docs/evmos.md) |
 | `Polkachu`   | [polkachu.com](https://www.polkachu.com/tendermint_snapshots/evmos)                   |                |
 | `Notional`   | [mainnet/pruned/evmos_9001-2(pebbledb)](https://snapshot.notional.ventures/evmos/) <br /> [mainnet/archive/evmos_9001-2(pebbledb)](https://snapshot.notional.ventures/evmos-archive/) <br /> [testnet/archive/evmos_9000-4(pebbledb)](https://snapshot.notional.ventures/evmos-testnet-archive/)                   |
+| `Windpowerstake`   | [mainnet/archive/evmos_9001-2(goleveldb)](http://backup03.windpowerstake.com/)                    |
 
 ### Archives
 


### PR DESCRIPTION
It makes sense to put it close to the notional archives.

windpowerstake will go updating goleveldb tar.gz snapshots of the full archive, indexed