### PR TITLE
Update networks list with Lava ipRPC

### DIFF
--- a/docs/develop/api/networks.mdx
+++ b/docs/develop/api/networks.mdx
@@ -21,6 +21,13 @@ If you are searching for the protobuf interfaces, head over [here](https://buf.b
 
 | Address                                       | Category               | Maintainer                              | Node Type  |
 | --------------------------------------------- | ---------------------- | --------------------------------------- | -----------|
+| `https://https://evmos.lava.build`            | `Ethereum` `JSON-RPC`  | [Lava Network](https://lavanet.xyz)             | Pruned     |
+| `wss://evmos.lava.build/websocket`            | `Ethereum` `WSS`       | [Lava Network](https://lavanet.xyz)             | Pruned     |
+| `https://rest.evmos.lava.build`               | `Cosmos` `REST`        | [Lava Network](https://lavanet.xyz)             | Pruned     |
+| `https://tm.evmos.lava.build`                 | `Tendermint` `RPC`     | [Lava Network](https://lavanet.xyz)             | Pruned     |
+| `wss://tm.evmos.lava.build/websocket`         | `Tendermint` `WSS`     | [Lava Network](https://lavanet.xyz)             | Pruned     |
+| `grpc.evmos.lava.build:443`                   | `Cosmos` `gRPC`        | [Lava Network](https://lavanet.xyz)             | Pruned     |
+| `https://grpc.evmos.lava.build`               | `Cosmos` `Web-gRPC`    | [Lava Network](https://lavanet.xyz)             | Pruned     |
 | `https://grpc.bd.evmos.org:9090`              | `Cosmos` `gRPC`        | [Blockdaemon](https://blockdaemon.com/) | Archival  |
 | `https://rest.bd.evmos.org:1317`              | `Cosmos` `REST`        | [Blockdaemon](https://blockdaemon.com/) | Archival  |
 | `https://tendermint.bd.evmos.org:26657`       | `Tendermint` `RPC`     | [Blockdaemon](https://blockdaemon.com/) | Archival  |
@@ -61,6 +68,13 @@ If you are searching for the protobuf interfaces, head over [here](https://buf.b
 
 | Address                                      | Category               | Maintainer                              | Node Type  |
 | --------------------------------------------- | ---------------------- | --------------------------------------- | -----------|
+| `https://evmos-testnet.lava.build`            | `Ethereum` `JSON-RPC`  | [Lava Network](https://lavanet.xyz)             | Pruned     |
+| `wss://evmos-testnet.lava.build/websocket`    | `Ethereum` `WSS`       | [Lava Network](https://lavanet.xyz)             | Pruned     |
+| `https://rest.evmos-testnet.lava.build`       | `Cosmos` `REST`        | [Lava Network](https://lavanet.xyz)             | Pruned     |
+| `https://tm.evmos-testnet.lava.build`         | `Tendermint` `RPC`     | [Lava Network](https://lavanet.xyz)             | Pruned     |
+| `wss://tm.evmos-testnet.lava.build/websocket` | `Tendermint` `WSS`     | [Lava Network](https://lavanet.xyz)             | Pruned     |
+| `grpc.evmos-testnet.lava.build:443`           | `Cosmos` `gRPC`        | [Lava Network](https://lavanet.xyz)             | Pruned     |
+| `https://grpc.evmos-testnet.lava.build`       | `Cosmos` `Web-gRPC`    | [Lava Network](https://lavanet.xyz)             | Pruned     |
 | `https://grpc.bd.evmos.dev:9090`             | `Cosmos` `gRPC`        | [Blockdaemon](https://blockdaemon.com/) | Archival  |
 | `https://rest.bd.evmos.dev:1317`             | `Cosmos` `REST`        | [Blockdaemon](https://blockdaemon.com/) | Archival  |
 | `https://tendermint.bd.evmos.dev:26657`      | `Tendermint` `RPC`     | [Blockdaemon](https://blockdaemon.com/) | Archival  |
@@ -80,10 +94,8 @@ If you are searching for the protobuf interfaces, head over [here](https://buf.b
 
 ### Lava
 
-Lava is the open standard for blockchain RPC and APIs. We make it easy for developers to build web3 applications using blockchain data.
-The Lava Gateway is a simplified web interface that gives developers instant access to blockchain data. The Gateway uses our Server Kit to provide a hosted point of access for developers looking for RPC through the Lava Network. This allows users to manage and configure Web3 APIs through an intuitive controls directly from the browser. While the Lava Server Kit and SDK give greater control and permissionlessness, the Lava Gateway provides the same access to our underlying network with additional niceties such as project management tools and user accounts. This means anyone, regardless of technical acumen, can easily use Lava.
+Lava is an open source protocol that serves as a p2p market for blockchain RPC & APIs. It gives wallets, dapps and indexers the most reliable RPC by optimally routing requests through a globally distributed network of node providers.
 
-- [Docs](https://docs.lavanet.xyz/)
-- Gateway [signup](https://accounts.lavanet.xyz/) is developers way to access Lava's RPC services.
-- [Gateway tutorial](https://docs.lavanet.xyz/gateway-getting-started)
-- Supports testnet and mainnet
+In simpler words, Lava pairs consumers and providers of RPC in a similar way to how Uber connects passengers and drivers. Users of Lava enjoy top quality of service and data reliability & accuracy, ensured by Lava protocol and the crypto-economic framework
+
+In partnership with Evmos, Lava is the providing a highly reliable, community-powered free public endpoints you can find above. If you’re looking for higher rate-limits and usage analytics, [check out the Lava Gateway](https://gateway.lavanet.xyz?utm_source=evmos-docs&utm_medium=referral&utm_campaign=evmos-iprpc).

--- a/docs/develop/api/networks.mdx
+++ b/docs/develop/api/networks.mdx
@@ -21,7 +21,7 @@ If you are searching for the protobuf interfaces, head over [here](https://buf.b
 
 | Address                                       | Category               | Maintainer                              | Node Type  |
 | --------------------------------------------- | ---------------------- | --------------------------------------- | -----------|
-| `https://https://evmos.lava.build`            | `Ethereum` `JSON-RPC`  | [Lava Network](https://lavanet.xyz)             | Pruned     |
+| `https://evmos.lava.build`                    | `Ethereum` `JSON-RPC`  | [Lava Network](https://lavanet.xyz)             | Pruned     |
 | `wss://evmos.lava.build/websocket`            | `Ethereum` `WSS`       | [Lava Network](https://lavanet.xyz)             | Pruned     |
 | `https://rest.evmos.lava.build`               | `Cosmos` `REST`        | [Lava Network](https://lavanet.xyz)             | Pruned     |
 | `https://tm.evmos.lava.build`                 | `Tendermint` `RPC`     | [Lava Network](https://lavanet.xyz)             | Pruned     |


### PR DESCRIPTION
This PR proposes a holistic update to `networks.md` inclusive of the following:

- ✅ Lava ipRPC endpoints for Mainnet are added.
- ✅ Lava ipRPC endpoints for Testnet are added.
- ✅ Lava description under heading `On-Demand Services` has been updated.

