### PR TITLE
chore: remove crisis module from list of modules

### DIFF
--- a/docs/protocol/modules/index.md
+++ b/docs/protocol/modules/index.md
@@ -27,7 +27,6 @@ Evmos uses the following Cosmos SDK modules:
 - [authz](https://docs.cosmos.network/main/modules/authz) - Authorization for accounts to perform actions on behalf of other accounts.
 - [bank](https://docs.cosmos.network/main/modules/bank) - Token transfer functionalities.
 - [capability](https://docs.cosmos.network/v0.47/modules/capability) - Object capability implementation.
-- [crisis](https://docs.cosmos.network/main/modules/crisis) - Halting the blockchain under certain circumstances (e.g. if an invariant is broken).
 - [distribution](https://docs.cosmos.network/main/modules/distribution) - Fee distribution, and staking token provision distribution.
 - [evidence](https://docs.cosmos.network/main/modules/evidence) - Evidence handling for double signing, misbehaviour, etc.
 - [feegrant](https://docs.cosmos.network/main/modules/feegrant) - Grant fee allowances for executing transactions.

--- a/docs/protocol/modules/index.md
+++ b/docs/protocol/modules/index.md
@@ -26,7 +26,7 @@ Evmos uses the following Cosmos SDK modules:
 - [auth](https://docs.cosmos.network/main/modules/auth) - Authentication of accounts and transactions for Cosmos SDK applications.
 - [authz](https://docs.cosmos.network/main/modules/authz) - Authorization for accounts to perform actions on behalf of other accounts.
 - [bank](https://docs.cosmos.network/main/modules/bank) - Token transfer functionalities.
-- [capability](https://docs.cosmos.network/v0.47/modules/capability) - Object capability implementation.
+- [capability](https://ibc.cosmos.network/main/ibc/capability-module) - Object capability implementation.
 - [distribution](https://docs.cosmos.network/main/modules/distribution) - Fee distribution, and staking token provision distribution.
 - [evidence](https://docs.cosmos.network/main/modules/evidence) - Evidence handling for double signing, misbehaviour, etc.
 - [feegrant](https://docs.cosmos.network/main/modules/feegrant) - Grant fee allowances for executing transactions.


### PR DESCRIPTION
This PR removes the `x/crisis` module from the list of modules.