### PR TITLE
docs(chain-id): Add note about non required bumps in the past

### DIFF
--- a/docs/protocol/concepts/chain-id.mdx
+++ b/docs/protocol/concepts/chain-id.mdx
@@ -14,7 +14,10 @@ follows the format of `identifier_EIP155-version` format.
 ## Official Chain IDs
 
 :::tip
-**NOTE**: The latest Chain ID (i.e highest Version Number) is the latest version of the software and mainnet.
+**NOTE**: The latest Chain ID (i.e highest Version Number) is the latest version of the software and mainnet. Also note, that the following upgrades technically did not require a Chain ID change:
+
+* `evmos_9001-1`	-> `evmos_9001-2`
+* `evmos_9000-3` -> `evmos_9000-4`
 :::
 
 ### Mainnet


### PR DESCRIPTION
## Description

Some Chain ID changes in the past were not required. Chain ID changes are only required, when starting a new network. This PR adds a note of that.

