### PR TITLE
imp(ci): Remove ignored URLs from Markdown Link Check

### DIFF
--- a/mlc_config.json
+++ b/mlc_config.json
@@ -1,76 +1,13 @@
 {
-    "ignorePatterns": [
-        {
-            "pattern": "^/"
-        },
-        {
-            "pattern": "^#"
-        },
-        {
-            "pattern": "^./"
-        },
-        {
-            "pattern": "^http://localhost:8877"
-        },
-        {
-            "pattern": "^http://localhost:9090"
-        },
-        {
-            "pattern": "^http://docs.evmos.org"
-        },
-        {
-            "pattern": "^http://community.evmos.org"
-        },
-        {
-            "pattern": "^http://academy.evmos.org"
-        },
-        {
-            "pattern": "^http://docs.tendermint.org"
-        },
-        {
-            "pattern": "^http://docs.cosmos.network"
-        },
-        {
-            "pattern": "^https://faucet.evmos.dev"
-        },
-        {
-            "pattern": "^https://en.wikipedia.org"
-        },
-        {
-            "pattern": "^https://immunefi.com/bounty/evmos"
-        },
-        {
-            "pattern": "^https://github.com/evmos"
-        },
-        {
-            "pattern": "^https://github.com/tendermint"
-        },
-        {
-            "pattern": "^https://eips.ethereum.org"
-        },
-        {
-            "pattern": "^https://medium.com"
-        },
-        {
-            "pattern": "^https://docs.docker.com"
-        },
-        {
-            "pattern": "^https://api.evmos.dev"
-        },
-        {
-            "pattern": "^https://api.evmos.org"
-        },
-        {
-            "pattern": "^https://www.keplr.app"
-        },
-        {
-            "pattern": "^https://metamask.io"
-        },
-        {
-            "pattern": "^https://evm.evmos.dev"
-        }
+  "ignorePatterns": [
+    {
+      "pattern": "^http://localhost:8877"
+    },
+    {
+      "pattern": "^http://localhost:9090"
+    },
   ],
-    "retryOn429": true,
-    "retryCount": 3,
-    "fallbackRetryDelay": "20s"
+  "retryOn429": true,
+  "retryCount": 3,
+  "fallbackRetryDelay": "20s"
 }


### PR DESCRIPTION
For a reason unbeknown to me, the `mlc_config.json` included a big list of URLs that were skipped being checked by the markdown link checker. This lead to a lot of missed dead links. This PR cleans that up.

Additionally, we are rather using individual escapes for links that are correct but return an error in the checks to mark them one by one instead of ignoring the whole website.