### PR TITLE
Update index.md

### DIFF
--- a/docs/develop/block-explorers/index.md
+++ b/docs/develop/block-explorers/index.md
@@ -18,7 +18,7 @@ Below is a list of public block explorers that support Evmos Mainnet and Testnet
 | Service    | Support        | URL                                                    | Contract Verification            |
 | ---------- | -------------- | ------------------------------------------------------ | -------------------------------- |
 | Mintscan   | `cosmos` `evm` | [mintscan.io/evmos](https://www.mintscan.io/evmos)     | Yes but requires form submission |
-| Escan      | `cosmos` `evm` | [escan.live](https://escan.live)                       | Permissionless                   |
+| OpenScan   | `evm`          | [evmos.openscan.ai](https://evmos.openscan.ai)         | Permissionless                   |
 | BigDipper  | `cosmos`       | [evmos.bigdipper.live/](https://evmos.bigdipper.live/) | No                               |
 | ATOMScan   | `cosmos`       | [atomscan.com/evmos](https://atomscan.com/evmos)       | No                               |
 | NGExplorer | `cosmos`       | [evmos.explorers.guru](https://evmos.explorers.guru)   | No                               |
@@ -27,7 +27,6 @@ Below is a list of public block explorers that support Evmos Mainnet and Testnet
 
 | Service    | Support        | URL                                                                            |
 | ---------- | -------------- | ------------------------------------------------------------------------------ |
-| Escan      | `cosmos` `evm` | [testnet.escan.live](https://testnet.escan.live)                               |
 | Mintscan   | `cosmos` `evm` | [testnet.mintscan.io/evmos-testnet](https://testnet.mintscan.io/evmos-testnet) |
 | BigDipper  | `cosmos`       | [testnet.bigdipper.live](https://testnet.evmos.bigdipper.live/)                |
 | Blockscout | `evm`          | [evm.evmos.dev](https://evm.evmos.dev/)                                        |


### PR DESCRIPTION
Removed escan.live, added evmos.openscan.ai

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced OpenScan as the new block explorer for the Mainnet, supporting the `evm` environment.
- **Bug Fixes**
	- Removed outdated entries for Escan from both Mainnet and Testnet sections of the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->